### PR TITLE
chore: fix style type on BreakRenderer

### DIFF
--- a/src/renderers/break.tsx
+++ b/src/renderers/break.tsx
@@ -1,10 +1,10 @@
 import { ReactNode } from "react";
-import { Text } from "react-native";
+import { StyleProp, Text, TextStyle } from "react-native";
 
 import { useMarkdownContext } from "../context";
 
 export const BreakRenderer = (): ReactNode => {
   const { styles } = useMarkdownContext();
 
-  return <Text style={styles.break}>{"\n"}</Text>;
+  return <Text style={styles.break as StyleProp<TextStyle>}>{"\n"}</Text>;
 };

--- a/src/renderers/list.tsx
+++ b/src/renderers/list.tsx
@@ -46,7 +46,7 @@ export const ListItemRenderer = ({
 
   return (
     <View style={{ flexDirection: "row" }}>
-      <View style={{ marginRight: 5 }}>
+      <View style={{ marginHorizontal: 8 }}>
         {list?.ordered ? (
           <Text style={markerStyle}>{itemNumber}.</Text>
         ) : (


### PR DESCRIPTION
## 📝 Description
Casts ViewStyle prop to StyleProp<TextStyle> in break.tsx renderer.

## 📌 Related Issue (Optional)

Closes #56 

## 📷 Screenshots (Optional)

<!--
Upload or embed screenshots here to show how your changes render in the app.
-->

## 📄 Test Markdown File (Optional)

<!--
Upload or link to the markdown file you used to test the rendering.
You can drag and drop it in the comment section after you create the PR.
-->

## ✅ Checklist

- [x] My PR title follows the Conventional Commit format (e.g. `feat:`, `fix:`, `chore:`)
- [x] This PR addresses the related issue (if applicable)
- [x] I have attached a sample Markdown file (`.md`) used for testing
- [x] I have attached at least one screenshot of the rendered output (light and/or dark mode preferred)
- [x] I have run `pnpm run lint:fix` to fix formatting and lint errors
- [x] I have tested the changes in the example app (`pnpm i && cd example && pnpm i && pnpm run ios`)
